### PR TITLE
Fix MacOS keyring errors, add `self` command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,14 +2,10 @@ name: test
 
 on:
   push:
-    branches:
-      - main
     paths-ignore:
       - "docs/**"
       - "*.md"
   pull_request:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,24 @@ The **third number** is the patch version (bug fixes)
 
 ## [Unreleased]() - 2024-mm-dd
 
+### Added
+
+- Help for MacOS users if Keychain is returning a `-25244` `errSecInvalidOwnerEdit` error.
+- `self keyring` command to manage the keyring.
+  - `self keyring status` to see information about the keyring used.
+
 ### Changed
 
-- Prompts are now printed to stderr instead of stdout.
+- Prompts are printed to stderr instead of stdout for POSIX compliance.
+
+### Fixed
+
+- Coroutines not being properly cancelled when the application exits abnormally.
+- Password not being stored in keyring after user is prompted for missing authentication info.
+
+### Deprecated
+
+- `cli-config` command. Use `self config`
 
 ## [0.2.0](https://github.com/unioslo/harbor-cli/tree/harbor-cli-v0.2.0) - 2023-12-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,15 +17,18 @@ The **third number** is the patch version (bug fixes)
 - Help for MacOS users if Keychain is returning a `-25244` `errSecInvalidOwnerEdit` error.
 - `self keyring` command to manage the keyring.
   - `self keyring status` to see information about the keyring used.
+- `self config` command to manage the configuration file.
+  - Has the same commands as `cli-config`, which is now deprecated.
 
 ### Changed
 
-- Prompts are printed to stderr instead of stdout for POSIX compliance.
+- Prompts now printed to stderr instead of stdout for POSIX compliance.
 
 ### Fixed
 
 - Coroutines not being properly cancelled when the application exits abnormally.
 - Password not being stored in keyring after user is prompted for missing authentication info.
+- Repeated keyring warnings if keyring is not available.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ The **third number** is the patch version (bug fixes)
 
 ### Changed
 
-- Prompts now printed to stderr instead of stdout for POSIX compliance.
+- Prompts are now printed to stderr instead of stdout for POSIX compliance.
+- Newlines are now logged as spaces in the log file.
 
 ### Fixed
 

--- a/harbor_cli/commands/api/artifact.py
+++ b/harbor_cli/commands/api/artifact.py
@@ -261,7 +261,7 @@ def get(
         "--with-vuln-desc",
         "-d",
         help="Include descriptions of each vulnerability in the output.",
-    )
+    ),
     # TODO: --tag
 ) -> None:
     """Get information about a specific artifact."""
@@ -269,7 +269,13 @@ def get(
     an = parse_artifact_name(artifact)
     # Just use normal endpoint method for a single artifact
     art = state.run(
-        get_artifact(state.client, an.project, an.repository, an.reference, with_report=with_vulnerabilities),  # type: ignore
+        get_artifact(
+            state.client,
+            an.project,
+            an.repository,
+            an.reference,
+            with_report=with_vulnerabilities,
+        ),  # type: ignore
         f"Fetching artifact(s)...",
     )
 
@@ -1038,7 +1044,7 @@ def get_vulnerabilities(
         f"Fetching artifacts...",
     )
 
-    report = ArtifactReport(artifacts)
+    report = ArtifactReport(artifacts=artifacts)
 
     affected = AffectedArtifactList()
     if operator == Operator.OR:

--- a/harbor_cli/commands/api/quotas.py
+++ b/harbor_cli/commands/api/quotas.py
@@ -55,7 +55,7 @@ def update_quota(
             "[red]NOTE:[/red] It is likely the property should always be [green]'storage'[/green] and the value an integer representing the quota size in bytes."
         ),
         metavar="PROP=VALUE, ...",
-    )
+    ),
     # status omitted
 ) -> None:
     """Update a quota."""

--- a/harbor_cli/commands/cli/__init__.py
+++ b/harbor_cli/commands/cli/__init__.py
@@ -1,14 +1,28 @@
 """Commands that are used to configure and interact with the CLI itself."""
 from __future__ import annotations
 
+import copy
+
 import typer
 
 from . import cache as cache
-from . import cli_config as cli_config
 from . import find as find
 from . import init as init
 from . import repl as repl
 from . import sample_config as sample_config
+from . import self as self
 from . import tui as tui
+from harbor_cli.style.style import render_cli_command
 
-cli_commands: list[typer.Typer] = [cli_config.app, cache.app]
+# Compatibility for deprecated `cli-config` command
+# Which now lives on as `self config`
+_cli_config_cmd = copy.deepcopy(self.config_cmd)
+_cli_config_cmd.info.name = "cli-config"
+_cli_config_cmd.info.deprecated = True
+_cli_config_cmd.info.hidden = True
+_cli_config_cmd.info.help = (
+    str(_cli_config_cmd.info.help)
+    + f" Use {render_cli_command('self config')} instead."
+)
+
+cli_commands: list[typer.Typer] = [self.app, _cli_config_cmd, cache.app]

--- a/harbor_cli/commands/cli/self.py
+++ b/harbor_cli/commands/cli/self.py
@@ -297,9 +297,9 @@ def env(
 def keyring_status(ctx: typer.Context) -> None:
     """Show the current keyring backend and its status."""
     from harbor_cli.utils.keyring import get_backend
-    from keyring.errors import NoKeyringError
+    from harbor_cli.utils.keyring import keyring_supported
 
-    try:
+    if keyring_supported():
         info(f"Keyring backend: {get_backend()}")
-    except NoKeyringError:
+    else:
         error("Keyring is not supported on this platform.")

--- a/harbor_cli/commands/cli/self.py
+++ b/harbor_cli/commands/cli/self.py
@@ -297,5 +297,9 @@ def env(
 def keyring_status(ctx: typer.Context) -> None:
     """Show the current keyring backend and its status."""
     from harbor_cli.utils.keyring import get_backend
+    from keyring.errors import NoKeyringError
 
-    info(f"Keyring backend: {get_backend()}")
+    try:
+        info(f"Keyring backend: {get_backend()}")
+    except NoKeyringError:
+        error("Keyring is not supported on this platform.")

--- a/harbor_cli/commands/cli/self.py
+++ b/harbor_cli/commands/cli/self.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import Optional
+from typing import TYPE_CHECKING
+
+import typer
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import ValidationError
+
+from ...config import DEFAULT_CONFIG_FILE
+from ...config import EnvVar
+from ...config import HarborCLIConfig
+from ...models import BaseModel
+from ...output.console import error
+from ...output.console import exit_err
+from ...output.console import exit_ok
+from ...output.console import info
+from ...output.console import print_toml
+from ...output.console import success
+from ...output.formatting.path import path_link
+from ...output.render import render_result
+from ...output.table._utils import get_table
+from ...output.table.anysequence import AnySequence
+from ...state import get_state
+from ...style import render_cli_command
+from ...style import render_cli_value
+from ...style import render_config_option
+from ...style.style import render_cli_option
+
+if TYPE_CHECKING:
+    from rich.table import Table
+
+# Create a command group
+app = typer.Typer(
+    name="self",
+    help="Manage the CLI itself.",
+    no_args_is_help=True,
+)
+
+config_cmd = typer.Typer(
+    name="config",
+    help="CLI configuration.",
+    no_args_is_help=True,
+)
+app.add_typer(config_cmd)
+
+keyring_cmd = typer.Typer(
+    name="keyring",
+    help="Manage keyring credentials.",
+    no_args_is_help=True,
+)
+app.add_typer(keyring_cmd)
+
+
+def render_config(config: HarborCLIConfig, as_toml: bool) -> None:
+    if as_toml:
+        print_toml(config.toml(expose_secrets=False))
+    else:
+        render_result(config)
+
+
+@config_cmd.callback()
+def callback(ctx: typer.Context) -> None:
+    state = get_state()
+    # Every other command than "path" and "write" requires a config file
+    if ctx.invoked_subcommand not in ["path", "write", "env"]:
+        # if not hasattr(state.config, "config_file") or state.config.config_file is None:
+        if state.config.config_file is None or not state.is_config_loaded:
+            exit_err(
+                "No configuration file loaded. A configuration file must exist to use this command."
+            )
+
+
+@config_cmd.command("get")
+def get_cli_config(
+    ctx: typer.Context,
+    # TODO: Add support for fetching keys with dot notation
+    key: Optional[str] = typer.Argument(
+        None, help="Specific config key to get value of."
+    ),
+    as_toml: bool = typer.Option(
+        True,
+        "--toml/--no-toml",
+        help="Show the current configuration in TOML format after setting the value. Overrides --format.",
+    ),
+) -> None:
+    """Show the current CLI configuration."""
+    state = get_state()
+    if key:
+        try:
+            if (attrs := key.split(".")) and len(attrs) > 1:
+                obj = getattr(state.config, attrs[0])
+                for attr in attrs[1:-1]:
+                    obj = getattr(obj, attr)
+                value = getattr(obj, attrs[-1])
+            else:
+                value = getattr(state.config, key)
+        except AttributeError:
+            exit_err(f"Invalid config key: {render_cli_value(key)}")
+        else:
+            render_result(value)
+    else:
+        render_config(state.config, as_toml)
+        if state.config.config_file is not None:
+            info(
+                f"[bold]Source:[/bold] {path_link(state.config.config_file)}",
+                panel=True,
+            )
+
+
+@config_cmd.command(
+    "keys",
+    help=f"Show all config keys that can be modified with {render_cli_command('set')}.",
+)
+def get_cli_config_keys(ctx: typer.Context) -> None:
+    state = get_state()
+
+    def get_fields(field: dict[str, Any], current: str) -> list[str]:
+        fields = []
+        if isinstance(field, dict):
+            for sub_key, sub_value in field.items():
+                f = get_fields(sub_value, f"{current}.{sub_key}")
+                fields.extend(f)
+        else:
+            fields.append(current)
+        return fields
+
+    ff = []
+    d = state.config.model_dump()
+    for key, value in d.items():
+        if isinstance(value, dict):
+            ff.extend(get_fields(value, key))
+        else:
+            ff.append(key)  # no subkeys
+
+    render_result(AnySequence(values=ff, title="Config Keys"))
+
+
+@config_cmd.command(
+    "set",
+    no_args_is_help=True,
+    help=f"Modify a CLI configuration value. Use {render_cli_command('keys')} to see all available keys.",
+)
+def set_cli_config(
+    ctx: typer.Context,
+    key: str = typer.Argument(
+        ...,
+        help="Key to set. Subkeys can be specified using dot notation. e.g. [green]'harbor.url'[/]",
+    ),
+    value: str = typer.Argument(..., help="Value to set."),
+    path: Path = typer.Option(None, "--path", help="Path to save configuration file."),
+    session: bool = typer.Option(
+        False,
+        "--session",
+        help="Set the value in the current session only. The value will not be saved to disk. Only useful in REPL mode.",
+    ),
+    show_config: bool = typer.Option(
+        False,
+        "--show/--no-show",
+        help="Show the current configuration after setting the value.",
+    ),
+    as_toml: bool = typer.Option(
+        True,
+        "--toml/--no-toml",
+        help="Render updated config as TOML in terminal if [green]--show[/] is set. Overrides global option [green]--format[/].",
+    ),
+) -> None:
+    if not key:
+        exit_err("No key specified.")
+
+    state = get_state()
+
+    try:
+        if (attrs := key.split(".")) and len(attrs) > 1:
+            obj = getattr(state.config, attrs[0])
+            for attr in attrs[1:-1]:
+                obj = getattr(obj, attr)
+            assert isinstance(obj, PydanticBaseModel)
+            to_set = attrs[-1]
+            if to_set not in obj.model_fields:
+                raise AttributeError
+            setattr(obj, attrs[-1], value)
+        else:
+            # Top-level primitive keys are supported, but we shouldn't have any!
+            # It's just here in case we do add it in the future.
+            # Overwriting top-level model keys is not allowed.
+            obj = getattr(state.config, key)
+            if isinstance(obj, PydanticBaseModel):
+                raise AttributeError("Overwriting config tables is not allowed.")
+            setattr(state.config, key, value)
+    except ValidationError as e:
+        # There should be at least one error, but we play it safe
+        errors = e.errors()
+        error = errors[0]["msg"] if errors else str(e)
+        exit_err(f"Invalid value for key {key!r}: {error}")
+    except (
+        ValueError,  # setattr failed for unknown model field (Pydantic)
+        AttributeError,  # getattr failed
+    ):
+        exit_err(f"Invalid config key: {key!r}")
+
+    if not session:
+        state.config.save(path=path)
+
+    if show_config:
+        render_config(state.config, as_toml)
+
+    success(f"Set {render_config_option(key)} to {render_cli_value(value)}")
+
+
+@config_cmd.command(
+    "write",
+    short_help="Write the current session configuration to disk.",
+    help=(
+        "Write the current [bold]session[/] configuration to disk. "
+        f"Used to save changes made with {render_cli_command('set --session')} in REPL mode."
+    ),
+)
+def write_session_config(
+    ctx: typer.Context,
+    path: Optional[Path] = typer.Option(
+        None,
+        "--path",
+        help="Path to save configuration file. Uses current config file path if not specified.",
+    ),
+) -> None:
+    state = get_state()
+    save_path = path or state.config.config_file
+    if save_path is None:
+        exit_err(
+            f"No path specified and no path found in current configuration. Use {render_cli_option('--path')} to specify a path."
+        )
+    state.config.save(path=save_path)
+    success(f"Saved configuration to [green]{save_path}[/]")
+
+
+@config_cmd.command(
+    "path",
+    help="Show the path to the current configuration file, or default path if no config is loaded.",
+)
+def show_config_path(ctx: typer.Context) -> None:
+    state = get_state()
+    path = state.config.config_file or DEFAULT_CONFIG_FILE
+    if not path.exists():
+        info("File does not exist.")
+    elif path.is_dir():
+        # this branch should be unreachable since HarborCLIConfig.from_file()
+        # should fail if the path is a directory
+        error(
+            "Path is a directory. Delete the directory so a config file can be created."
+        )
+    elif not path.read_text().strip():
+        info("File exists, but is empty.")
+    render_result(path, ctx)
+
+
+# TODO: add reload config command
+
+
+class EnvVars(BaseModel):
+    envvars: Dict[str, str] = {}
+
+    def as_table(self, **kwargs: Any) -> Iterable[Table]:  # type: ignore
+        table = get_table("Environment Variables", columns=["Variable", "Value"])
+        for envvar, value in self.envvars.items():
+            table.add_row(envvar, value)
+        yield table
+
+
+@config_cmd.command()
+def env(
+    ctx: typer.Context,
+    all: bool = typer.Option(
+        False, "-a", "--all", help="List all environment variables."
+    ),
+) -> None:
+    """Show active Harbor CLI environment variables."""
+    active = {}
+    for env_var in sorted(EnvVar):
+        val = os.environ.get(env_var)
+        if not all and val is None:
+            continue
+        active[str(env_var)] = val or ""
+
+    if not active:
+        exit_ok("No environment variables set.")
+
+    render_result(EnvVars(envvars=active))
+
+
+@keyring_cmd.command("status")
+def keyring_status(ctx: typer.Context) -> None:
+    """Show the current keyring backend and its status."""
+    from harbor_cli.utils.keyring import get_backend
+
+    info(f"Keyring backend: {get_backend()}")

--- a/harbor_cli/exceptions.py
+++ b/harbor_cli/exceptions.py
@@ -51,6 +51,10 @@ class OverwriteError(HarborCLIError, FileExistsError):
     """Error overwriting an existing file."""
 
 
+class KeyringUnsupportedError(HarborCLIError):
+    """Keyring is not supported on this system."""
+
+
 class ArtifactNameFormatError(HarborCLIError):
     def __init__(self, s: str) -> None:
         super().__init__(

--- a/harbor_cli/exceptions.py
+++ b/harbor_cli/exceptions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from typing import Any
 from typing import cast
 from typing import Dict
@@ -24,6 +25,9 @@ from httpx._exceptions import CookieConflict
 from httpx._exceptions import HTTPError
 from httpx._exceptions import InvalidURL
 from httpx._exceptions import StreamError
+from keyring.errors import KeyringError
+from keyring.errors import PasswordDeleteError
+from keyring.errors import PasswordSetError
 from pydantic import ValidationError
 
 
@@ -159,6 +163,47 @@ def handle_status_error(e: StatusError, exiter: Exiter) -> NoReturn:
     exit_err(msg)
 
 
+def handle_keyring_error(e: KeyringError, exiter: Exiter) -> NoReturn:
+    """Handles a keyring error and exits with the appropriate message."""
+    if sys.platform == "darwin":
+        if (
+            isinstance(e, (PasswordSetError, PasswordDeleteError))
+            and e.__context__
+            and e.__context__.args
+            and e.__context__.args[0] == -25244
+        ):
+            _handle_keyring_error_25244_macos(e, exiter)
+    exiter(f"A keyring error occurred: {e}", exc_info=True)
+
+
+def _handle_keyring_error_25244_macos(e: KeyringError, exiter: Exiter) -> bool:
+    """Handles macOS keyring error -25244 (errSecInvalidOwnerEdit error) when setting
+    a password
+
+    This very likely happens if we try to access the keyring from an application
+    that is not signed with the same certificate as the one that created the keychain
+    item initially.
+
+    See: https://developer.apple.com/forums/thread/69841
+    See: https://github.com/python-poetry/poetry/issues/2692#issuecomment-1382387632
+    """
+    from harbor_cli.utils.keyring import KEYRING_SERVICE_NAME
+
+    actions = {
+        PasswordSetError: "set",
+        PasswordDeleteError: "delete",
+    }
+    action = actions.get(type(e), "access")
+
+    exiter(
+        f"An error occurred while trying to {action} a password in your keyring.\n"
+        f"Please delete any passwords related to [i]{KEYRING_SERVICE_NAME}[/] from your keyring "
+        "and try again.\n"
+        "If this issue persists, please report it and disable keyring in your config file.\n"
+        "Run [i]harbor cli-config path[/] to find the location of your config file."
+    )
+
+
 def handle_validationerror(e: ValidationError, exiter: Exiter) -> NoReturn:
     """Handles a pydantic ValidationError and exits with the appropriate message."""
     exiter(f"Failed to validate data from API: {e}", errors=e.errors(), exc_info=True)
@@ -177,6 +222,7 @@ EXC_HANDLERS: Mapping[Type[Exception], HandleFunc] = {
     InvalidURL: handle_notraceback,
     CookieConflict: handle_notraceback,
     StreamError: handle_notraceback,
+    KeyringError: handle_keyring_error,
 }
 
 

--- a/harbor_cli/harbor/common.py
+++ b/harbor_cli/harbor/common.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from ..output.prompts import no_headless
 from ..output.prompts import path_prompt
 from ..output.prompts import str_prompt
 
 
+@no_headless
 def prompt_username_secret(
     default_username: str | None = None, default_secret: str | None = None
 ) -> tuple[str, str]:

--- a/harbor_cli/logs.py
+++ b/harbor_cli/logs.py
@@ -72,9 +72,18 @@ def setup_logging(config: LoggingSettings) -> None:
     logger.disabled = False
 
 
+class LogLineFormatter(logging.Formatter):
+    """Replaces newlines in log messages with spaces."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format the log message."""
+        record.msg = record.msg.replace("\n", " ")
+        return super().format(record)
+
+
 def _get_file_handler(config: LoggingSettings) -> logging.FileHandler:
     file_handler = logging.FileHandler(config.path)
-    formatter = logging.Formatter(
+    formatter = LogLineFormatter(
         "%(asctime)s [%(levelname)s] [%(module)s:%(filename)s:%(lineno)s - %(funcName)s()] %(message)s"
     )
     file_handler.setFormatter(formatter)

--- a/harbor_cli/output/console.py
+++ b/harbor_cli/output/console.py
@@ -89,6 +89,9 @@ def get_renderable(
     if bold:
         msg = bold_func(msg)
 
+    # Indent multiline strings to follow icon + space
+    msg = msg.replace("\n", "\n" + " " * (len(str(icon)) + 1))
+
     if panel:
         renderables.append(Panel(msg, expand=False))
     else:
@@ -136,7 +139,7 @@ def warning(
             get_renderable(
                 message,
                 icon=Icon.WARNING,
-                color="yellow",
+                color="gold3",
                 preamble="WARNING",
                 color_all=True,  # entire message is yellow
                 rule=rule,
@@ -157,7 +160,13 @@ def error(
     logger.error(message, extra=dict(**kwargs), exc_info=exc_info)
     err_console.print(
         get_renderable(
-            message, icon=Icon.ERROR, color="red", rule=rule, panel=panel, bold=True
+            message,
+            icon=Icon.ERROR,
+            color="red",
+            color_all=True,
+            rule=rule,
+            panel=panel,
+            bold=True,
         )
     )
 

--- a/harbor_cli/state.py
+++ b/harbor_cli/state.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+from functools import cached_property
 from pathlib import Path
-from typing import Awaitable
+from typing import Coroutine
 from typing import Optional
 from typing import TYPE_CHECKING
 from typing import TypeVar
@@ -18,6 +19,7 @@ from rich.console import Console
 
 if TYPE_CHECKING:
     from .config import HarborCLIConfig
+    from logging import Logger
 
 
 T = TypeVar("T")
@@ -49,6 +51,7 @@ class State:
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:
             cls._instance = super().__new__(cls, *args, **kwargs)
+            cls._initialized = False
         return cls._instance
 
     options: CommonOptions = CommonOptions()
@@ -78,6 +81,9 @@ class State:
         client : HarborAsyncClient | None
             Harbor client to override the default client with.
         """
+        if self._initialized:  # prevent __init__ from running more than once
+            return
+
         # NOTE: these overrides are used mainly for testing
         if config:
             self.config = config
@@ -88,6 +94,8 @@ class State:
         except RuntimeError:
             self.loop = asyncio.new_event_loop()
         self.options = CommonOptions()
+
+        self._initialized = True
 
     @property
     def client(self) -> HarborAsyncClient:
@@ -156,6 +164,13 @@ class State:
         return self._console
         # fmt: on
 
+    @cached_property
+    def logger(self) -> Logger:
+        """Logger object."""
+        from .logs import logger
+
+        return logger
+
     def authenticate_harbor(self) -> None:
         self.client.authenticate(**self.config.harbor.credentials)
 
@@ -165,10 +180,6 @@ class State:
         Prompts for necessary authentication info if it's missing from the config.
         """
         from .harbor.common import prompt_url
-        from .harbor.common import prompt_username_secret
-        from .style.style import render_cli_command
-        from .style.style import render_cli_option
-        from .style.style import render_cli_value
         from .output.console import warning
 
         if not self.config.harbor.url:
@@ -181,13 +192,9 @@ class State:
             warning(
                 "Harbor authentication method is missing or incomplete in configuration file."
             )
-            username, secret = prompt_username_secret(self.config.harbor.username, "")
-            self.config.harbor.username = username
-            self.config.harbor.secret = secret  # type: ignore # pydantic.SecretStr
-            warning(
-                "Authentication info updated. "
-                f"Run {render_cli_command('harbor init')} to configure it permanently. "
-                f"Suppress this warning by setting {render_cli_option('general.warnings')} to {render_cli_value('false')}."
+            self.config.harbor.set_username_secret(
+                current_username=self.config.harbor.username,
+                current_secret=self.config.harbor.secret_value,
             )
 
         self.authenticate_harbor()
@@ -206,7 +213,7 @@ class State:
 
     def run(
         self,
-        coro: Awaitable[T],
+        coro: Coroutine[None, None, T],
         status: Optional[str] = None,
         no_handle: type[Exception] | tuple[type[Exception], ...] | None = None,
     ) -> T:
@@ -214,7 +221,7 @@ class State:
 
         Parameters
         ----------
-        coro : Awaitable[T]
+        coro : Coroutine[None, None, T]
             The coroutine to run, which returns type T.
         status : str, optional
             The status message to display while the coroutine is running.
@@ -232,29 +239,39 @@ class State:
         --------
         [harbor_cli.exceptions.handle_exception][]
         """
-        # Make sure client is loaded and configured
-        if not self.is_client_loaded:
-            self._init_client()
-        else:
-            self.authenticate_harbor()  # ensure we use newest credentials
-
-        if not status:
-            status = "Working..."
-        if not status.endswith("..."):  # aesthetic :)
-            status += "..."
-
-        # show spinner when running a coroutine
         try:
-            with self.console.status(status):
-                resp = self.loop.run_until_complete(coro)
-        except Exception as e:
-            if no_handle and isinstance(e, no_handle):
-                raise e
-            # fmt: off
-            from .exceptions import handle_exception
-            handle_exception(e)
-            # fmt: on
-        return resp
+            # Make sure client is loaded and configured
+            if not self.is_client_loaded:
+                self._init_client()
+            else:
+                self.authenticate_harbor()  # ensure we use newest credentials
+
+            if not status:
+                status = "Working..."
+            if not status.endswith("..."):  # aesthetic :)
+                status += "..."
+
+            # show spinner when running a coroutine
+            try:
+                with self.console.status(status):
+                    resp = self.loop.run_until_complete(coro)
+            except Exception as e:
+                if no_handle and isinstance(e, no_handle):
+                    raise e
+                # fmt: off
+                from .exceptions import handle_exception
+                handle_exception(e)
+                # fmt: on
+            return resp
+        finally:
+            # Close coro in case we never got to run it
+            # Unawaited coros emit warnings which we ideally want to know about
+            # But if we error before getting to run it, we don't need a warning
+            try:
+                coro.close()
+            except Exception:
+                self.logger.debug("Failed to close coroutine.", exc_info=True)
+                pass
 
 
 def get_state() -> State:

--- a/harbor_cli/style/color.py
+++ b/harbor_cli/style/color.py
@@ -32,11 +32,24 @@ def yellow(message: str) -> str:
     return f"[yellow]{message}[/]"
 
 
+def gold3(message: str) -> str:
+    return f"[gold3]{message}[/]"
+
+
 def bold(message: str) -> str:
     return f"[bold]{message}[/]"
 
 
-Color = Literal["blue", "cyan", "green", "magenta", "red", "yellow", "bold"]
+Color = Literal[
+    "blue",
+    "cyan",
+    "green",
+    "magenta",
+    "red",
+    "yellow",
+    "bold",
+    "gold3",
+]
 ColorFunc = Callable[[str], str]
 COLOR_FUNCTIONS: Dict[Color, ColorFunc] = {
     "blue": blue,
@@ -46,11 +59,23 @@ COLOR_FUNCTIONS: Dict[Color, ColorFunc] = {
     "red": red,
     "yellow": yellow,
     "bold": bold,
+    "gold3": gold3,
 }
 
 
+def fallback_color(message: str) -> str:
+    """Returns the string as-is."""
+    return message
+
+
 def get_color_func(color: Color) -> ColorFunc:
-    return COLOR_FUNCTIONS[color]
+    try:
+        return COLOR_FUNCTIONS[color]
+    except KeyError:
+        from harbor_cli.logs import logger
+
+        logger.error("Invalid color: %s", color, stacklevel=2)
+        return fallback_color
 
 
 class HealthColor(StrEnum):
@@ -89,6 +114,10 @@ class SeverityColor(StrEnum):
 
     @classmethod
     def as_markup(cls, severity: str | Severity) -> str:
-        """Return the given severity as a Rich markup-formatted string."""
+        """Return the given severity as a Rich markup-formatted string.
+
+        I.e. "[dark_red]CRITICAL[/]" for Severity.CRITICAL, etc."""
         color = cls.from_severity(severity)
-        return f"[{color}]{severity}[/]"
+        if isinstance(severity, Severity):
+            severity = severity.value
+        return f"[{color}]{severity.upper()}[/]"

--- a/harbor_cli/utils/commands.py
+++ b/harbor_cli/utils/commands.py
@@ -59,13 +59,16 @@ def _get_app_commands(
     else:
         raise TypeError(f"Unexpected app type: {type(app)}")
 
+    groups: dict[str, TyperGroup | TyperCommand] = {}
     try:
         groups = cmd.commands  # type: ignore
     except AttributeError:
-        groups = {}
+        pass
 
     # If we have subcommands, we need to go deeper.
     for command in groups.values():
+        if command.deprecated:  # skip deprecated commands
+            continue
         if current == "":
             cmd_name = command.name or ""
         else:

--- a/harbor_cli/utils/keyring.py
+++ b/harbor_cli/utils/keyring.py
@@ -1,43 +1,89 @@
 from __future__ import annotations
 
 import functools
+import sys
 from typing import Callable
+from typing import TYPE_CHECKING
 from typing import TypeVar
 
 import keyring
+from keyring.errors import KeyringError
+from keyring.errors import PasswordDeleteError
+from keyring.errors import PasswordSetError
 from typing_extensions import ParamSpec
 
-from ..logs import logger
-from ..output.console import info
+from harbor_cli.exceptions import KeyringUnsupportedError
+from harbor_cli.logs import logger
+from harbor_cli.output.console import info
+from harbor_cli.output.console import warning
+
+if TYPE_CHECKING:
+    from keyring.backend import KeyringBackend
 
 KEYRING_SERVICE_NAME = "harbor_cli"
+_KEYRING_DUMMY_USER = "test_user"
+_KEYRING_DUMMY_PASSWORD = "test_password"
 
 
-class KeyringUnsupportedError(Exception):
-    pass
+class DummyPasswordNoMatchError(Exception):
+    """Raised when the keyring dummy password does not match."""
 
 
 @functools.lru_cache(maxsize=1)
-def keyring_supported():
-    dummy_user = "test_user"
-    dummy_password = "test_password"
-    try:
-        # Set and get a dummy password to test the backend
-        keyring.set_password(KEYRING_SERVICE_NAME, dummy_user, dummy_password)
-        password = keyring.get_password(KEYRING_SERVICE_NAME, dummy_user)
+def keyring_supported() -> bool:
+    """Very naively checks if we can use keyring on the current system.
 
-        # Check if the password was correctly retrieved
-        if password == dummy_password:
-            return True
+    We set a dummy password and then try to retrieve it. If we get the same
+    password back, we assume that keyring is supported."""
+    try:
+        backend = get_backend()
+        logger.debug("Using keyring backend: %s", backend)
+    except KeyringError as e:
+        if sys.platform == "darwin":
+            if (
+                isinstance(e, (PasswordSetError, PasswordDeleteError))
+                and e.__context__
+                and e.__context__.args
+                and e.__context__.args[0] == -25244
+            ):
+                return _handle_keyring_error_25244_macos(e)
         else:
-            raise keyring.errors.KeyringError(
-                "Keyring backend did not return the correct password."
-            )
-    # TODO: make this error handling more robust. Differentiate between different
-    # keyring errors and handle them accordingly.
-    except (keyring.errors.KeyringError, KeyringUnsupportedError) as e:
-        logger.debug(f"Keyring is not supported on this platform: {e}", exc_info=True)
+            logger.error("Keyring error: %s", e)
         return False
+    except Exception as e:
+        logger.error(
+            "Unknown error when checking keyring availability: %s", e, exc_info=True
+        )
+        return False
+    else:
+        return True
+
+
+def _handle_keyring_error_25244_macos(e: KeyringError) -> bool:
+    """Handles macOS keyring error -25244 (errSecInvalidOwnerEdit error) when setting
+    a password
+
+    This very likely happens if we try to access the keyring from an application
+    that is not signed with the same certificate as the one that created the keychain
+    item initially.
+
+    See: https://developer.apple.com/forums/thread/69841
+    See: https://github.com/python-poetry/poetry/issues/2692#issuecomment-1382387632
+    """
+    actions = {
+        PasswordSetError: "set",
+        PasswordDeleteError: "delete",
+    }
+    action = actions.get(type(e), "access")
+
+    warning(
+        f"An error occurred while trying to {action} a password in your keyring.\n"
+        f"Please delete any passwords related to [i]{KEYRING_SERVICE_NAME}[/] from your keyring "
+        "and try again.\n"
+        "If this issue persists, please report it and disable keyring in your config file.\n"
+        "Run [i]harbor cli-config path[/] to find the location of your config file."
+    )
+    return False
 
 
 P = ParamSpec("P")
@@ -70,3 +116,12 @@ def set_password(username: str, password: str) -> None:
 def delete_password(username: str) -> None:
     keyring.delete_password(KEYRING_SERVICE_NAME, username)
     info("Deleted password from keyring.", user=username)
+
+
+def get_backend() -> KeyringBackend:
+    return keyring.get_keyring()
+
+
+def clear_supported_cache() -> None:
+    """Clears the keyring availability cache."""
+    keyring_supported.cache_clear()

--- a/harbor_cli/utils/keyring.py
+++ b/harbor_cli/utils/keyring.py
@@ -32,7 +32,7 @@ def keyring_supported() -> bool:
     password back, we assume that keyring is supported."""
     try:
         backend = get_backend()
-        if backend == keyring.backends.fail.Keyring:
+        if isinstance(backend, keyring.backends.fail.Keyring):
             raise NoKeyringError
         logger.debug("Using keyring backend: %s", backend)
         return True

--- a/harbor_cli/utils/keyring.py
+++ b/harbor_cli/utils/keyring.py
@@ -38,7 +38,6 @@ def keyring_supported() -> bool:
         pass  # does not need to be logged
     except KeyringError as e:
         logger.error("Keyring error: %s", e, exc_info=True)
-        return False
     except Exception as e:
         logger.error(
             "Unknown error when checking keyring availability: %s", e, exc_info=True

--- a/harbor_cli/utils/keyring.py
+++ b/harbor_cli/utils/keyring.py
@@ -1,28 +1,23 @@
 from __future__ import annotations
 
 import functools
-import sys
 from typing import Callable
 from typing import TYPE_CHECKING
 from typing import TypeVar
 
 import keyring
 from keyring.errors import KeyringError
-from keyring.errors import PasswordDeleteError
-from keyring.errors import PasswordSetError
+from keyring.errors import NoKeyringError
 from typing_extensions import ParamSpec
 
 from harbor_cli.exceptions import KeyringUnsupportedError
 from harbor_cli.logs import logger
 from harbor_cli.output.console import info
-from harbor_cli.output.console import warning
 
 if TYPE_CHECKING:
     from keyring.backend import KeyringBackend
 
 KEYRING_SERVICE_NAME = "harbor_cli"
-_KEYRING_DUMMY_USER = "test_user"
-_KEYRING_DUMMY_PASSWORD = "test_password"
 
 
 class DummyPasswordNoMatchError(Exception):
@@ -38,51 +33,16 @@ def keyring_supported() -> bool:
     try:
         backend = get_backend()
         logger.debug("Using keyring backend: %s", backend)
+        return True
+    except NoKeyringError:
+        pass  # does not need to be logged
     except KeyringError as e:
-        if sys.platform == "darwin":
-            if (
-                isinstance(e, (PasswordSetError, PasswordDeleteError))
-                and e.__context__
-                and e.__context__.args
-                and e.__context__.args[0] == -25244
-            ):
-                return _handle_keyring_error_25244_macos(e)
-        else:
-            logger.error("Keyring error: %s", e)
+        logger.error("Keyring error: %s", e, exc_info=True)
         return False
     except Exception as e:
         logger.error(
             "Unknown error when checking keyring availability: %s", e, exc_info=True
         )
-        return False
-    else:
-        return True
-
-
-def _handle_keyring_error_25244_macos(e: KeyringError) -> bool:
-    """Handles macOS keyring error -25244 (errSecInvalidOwnerEdit error) when setting
-    a password
-
-    This very likely happens if we try to access the keyring from an application
-    that is not signed with the same certificate as the one that created the keychain
-    item initially.
-
-    See: https://developer.apple.com/forums/thread/69841
-    See: https://github.com/python-poetry/poetry/issues/2692#issuecomment-1382387632
-    """
-    actions = {
-        PasswordSetError: "set",
-        PasswordDeleteError: "delete",
-    }
-    action = actions.get(type(e), "access")
-
-    warning(
-        f"An error occurred while trying to {action} a password in your keyring.\n"
-        f"Please delete any passwords related to [i]{KEYRING_SERVICE_NAME}[/] from your keyring "
-        "and try again.\n"
-        "If this issue persists, please report it and disable keyring in your config file.\n"
-        "Run [i]harbor cli-config path[/] to find the location of your config file."
-    )
     return False
 
 

--- a/harbor_cli/utils/keyring.py
+++ b/harbor_cli/utils/keyring.py
@@ -5,7 +5,7 @@ from typing import Callable
 from typing import TYPE_CHECKING
 from typing import TypeVar
 
-import keyring
+import keyring.backends.fail
 from keyring.errors import KeyringError
 from keyring.errors import NoKeyringError
 from typing_extensions import ParamSpec
@@ -32,6 +32,8 @@ def keyring_supported() -> bool:
     password back, we assume that keyring is supported."""
     try:
         backend = get_backend()
+        if backend == keyring.backends.fail.Keyring:
+            raise NoKeyringError
         logger.debug("Using keyring backend: %s", backend)
         return True
     except NoKeyringError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,7 @@ def config(log_dir: Path) -> HarborCLIConfig:
     conf.harbor.url = "https://harbor.example.com/api/v2.0"
     conf.harbor.username = "admin"
     conf.harbor.secret = SecretStr("password")
+    conf.harbor.keyring = False
     conf.logging.directory = log_dir
     return conf
 

--- a/tests/output/test_color.py
+++ b/tests/output/test_color.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import typing
+from typing import Tuple
+
+import pytest
+
+from harbor_cli.style.color import Color
+from harbor_cli.style.color import COLOR_FUNCTIONS
+from harbor_cli.style.color import fallback_color
+from harbor_cli.style.color import get_color_func
+from harbor_cli.style.color import Severity
+from harbor_cli.style.color import SeverityColor
+
+
+def test_from_severity():
+    assert SeverityColor.from_severity("CRITICAL") == SeverityColor.CRITICAL
+    assert SeverityColor.from_severity("HIGH") == SeverityColor.HIGH
+    assert SeverityColor.from_severity("MEDIUM") == SeverityColor.MEDIUM
+    assert SeverityColor.from_severity("LOW") == SeverityColor.LOW
+    assert SeverityColor.from_severity("NEGLIGIBLE") == SeverityColor.NEGLIGIBLE
+    assert SeverityColor.from_severity("NONE") == SeverityColor.NONE
+    assert SeverityColor.from_severity("UNKNOWN") == SeverityColor.UNKNOWN
+
+    assert SeverityColor.from_severity(Severity.critical) == SeverityColor.CRITICAL
+    assert SeverityColor.from_severity(Severity.high) == SeverityColor.HIGH
+    assert SeverityColor.from_severity(Severity.medium) == SeverityColor.MEDIUM
+    assert SeverityColor.from_severity(Severity.low) == SeverityColor.LOW
+    assert SeverityColor.from_severity(Severity.negligible) == SeverityColor.NEGLIGIBLE
+    assert SeverityColor.from_severity(Severity.none) == SeverityColor.NONE
+    assert SeverityColor.from_severity(Severity.unknown) == SeverityColor.UNKNOWN
+
+    assert SeverityColor.from_severity("INVALID") == SeverityColor.UNKNOWN
+
+
+def test_as_markup():
+    # TODO: less hardcoding of the color names perhaps?
+    assert SeverityColor.as_markup("CRITICAL") == "[dark_red]CRITICAL[/]"
+    assert SeverityColor.as_markup("HIGH") == "[red]HIGH[/]"
+    assert SeverityColor.as_markup("MEDIUM") == "[orange3]MEDIUM[/]"
+    assert SeverityColor.as_markup("LOW") == "[green]LOW[/]"
+    assert SeverityColor.as_markup("NEGLIGIBLE") == "[blue]NEGLIGIBLE[/]"
+    assert SeverityColor.as_markup("NONE") == "[white]NONE[/]"
+    assert SeverityColor.as_markup("UNKNOWN") == "[white]UNKNOWN[/]"
+
+    assert SeverityColor.as_markup(Severity.critical) == "[dark_red]CRITICAL[/]"
+    assert SeverityColor.as_markup(Severity.high) == "[red]HIGH[/]"
+    assert SeverityColor.as_markup(Severity.medium) == "[orange3]MEDIUM[/]"
+    assert SeverityColor.as_markup(Severity.low) == "[green]LOW[/]"
+    assert SeverityColor.as_markup(Severity.negligible) == "[blue]NEGLIGIBLE[/]"
+    assert SeverityColor.as_markup(Severity.none) == "[white]NONE[/]"
+    assert SeverityColor.as_markup(Severity.unknown) == "[white]UNKNOWN[/]"
+
+
+def test_assert_color_mapping_parity() -> None:
+    """Ensure the `Color` type annotation and `COLOR_FUNCTIONS` dict are in sync."""
+    args: Tuple[str] = typing.get_args(Color)
+    assert len(args) > 0  # ensure we are iterating over _something_
+    assert len(args) == len(COLOR_FUNCTIONS)
+    for arg in args:
+        assert arg in COLOR_FUNCTIONS
+
+
+def test_get_color_func_valid() -> None:
+    args: Tuple[str] = typing.get_args(Color)
+    assert len(args) > 0  # ensure we are iterating over _something_
+    for arg in args:
+        func = get_color_func(arg)  # type: ignore
+        assert func == COLOR_FUNCTIONS[arg]  # type: ignore
+        res = func("test")
+        assert "]test[/]" in res
+
+
+def test_get_color_func_invalid(caplog: pytest.LogCaptureFixture) -> None:
+    """An invalid color func name simply returns the string as-is."""
+    func = get_color_func("INVALID COLOR")  # type: ignore
+    assert func == fallback_color  # type: ignore
+    # Fallback returns text as-is
+    assert func("test") == "test"  # type: ignore
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.levelname == "ERROR"
+    assert "Invalid color:" in record.message
+    # Ensure the stacklevel=2 logging call logs the caller of get_color_func,
+    # rather than get_color_func itself.
+    assert "test_color.py" in record.filename

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -154,7 +154,7 @@ def test_auth_precedence(
     mocker: pytest_mock.MockFixture,
 ) -> None:
     @app.command("test-cmd")
-    def test_cmd(ctx: typer.Context) -> None:
+    def test_cmd(ctx: typer.Context) -> int:
         async def some_func() -> None:
             pass
 
@@ -177,7 +177,7 @@ def test_auth_precedence(
     for method in secret_values:
         # Configure from lowest to highest precedence
         if method <= SecretMethod.CONFIG:
-            state.config.harbor.secret = secret_values[SecretMethod.CONFIG]
+            state.config.harbor.secret = secret_values[SecretMethod.CONFIG]  # type: ignore # converted by pydantic
             state.config.harbor.keyring = False
         if method <= SecretMethod.KEYRING:
             set_password(HARBOR_CLI_TEST_USERNAME, secret_values[SecretMethod.KEYRING])

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from enum import Enum
 from enum import IntEnum
 from pathlib import Path
+from typing import Iterable
 
 import pytest
 import pytest_mock
@@ -124,7 +125,7 @@ HARBOR_CLI_TEST_USERNAME = "harbor_cli_test_user"
 
 
 @pytest.fixture(scope="function")
-def reset_keyring() -> None:
+def reset_keyring() -> Iterable[None]:
     """Clears the test user from the keyring.
     Should only be used by functions decorated with @requires_keyring"""
     yield

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -160,8 +160,6 @@ def test_auth_precedence(
     reset_keyring: None,
     mocker: pytest_mock.MockFixture,
 ) -> None:
-    assert get_backend() == "foo"
-
     @app.command("test-cmd")
     def test_cmd(ctx: typer.Context) -> int:
         async def some_func() -> None:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -20,6 +20,7 @@ from harbor_cli.config import EnvVar
 from harbor_cli.format import OutputFormat
 from harbor_cli.state import State
 from harbor_cli.utils.keyring import delete_password
+from harbor_cli.utils.keyring import get_backend
 from harbor_cli.utils.keyring import keyring_supported
 from harbor_cli.utils.keyring import set_password
 
@@ -159,7 +160,7 @@ def test_auth_precedence(
     reset_keyring: None,
     mocker: pytest_mock.MockFixture,
 ) -> None:
-    assert keyring_supported()
+    assert get_backend() == "foo"
 
     @app.command("test-cmd")
     def test_cmd(ctx: typer.Context) -> int:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,6 +5,7 @@ from enum import IntEnum
 from pathlib import Path
 from typing import Iterable
 
+import keyring
 import pytest
 import pytest_mock
 import typer
@@ -19,6 +20,7 @@ from harbor_cli.config import EnvVar
 from harbor_cli.format import OutputFormat
 from harbor_cli.state import State
 from harbor_cli.utils.keyring import delete_password
+from harbor_cli.utils.keyring import keyring_supported
 from harbor_cli.utils.keyring import set_password
 
 
@@ -157,6 +159,8 @@ def test_auth_precedence(
     reset_keyring: None,
     mocker: pytest_mock.MockFixture,
 ) -> None:
+    assert keyring_supported()
+
     @app.command("test-cmd")
     def test_cmd(ctx: typer.Context) -> int:
         async def some_func() -> None:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,6 +9,7 @@ import pytest
 import pytest_mock
 import typer
 from harborapi.utils import get_basicauth
+from keyring.errors import NoKeyringError
 from keyring.errors import PasswordDeleteError
 from typer.testing import Result
 
@@ -131,6 +132,8 @@ def reset_keyring() -> Iterable[None]:
     yield
     try:
         delete_password(HARBOR_CLI_TEST_USERNAME)
+    except NoKeyringError:
+        pass
     except PasswordDeleteError as e:
         # Ignore if password was deleted by the test
         if "not found" not in str(e):  # pragma: no cover

--- a/tests/test_keyring.py
+++ b/tests/test_keyring.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import keyring
 import pytest
+from keyring.errors import NoKeyringError
 
 from .conftest import requires_keyring
 from .conftest import requires_no_keyring
@@ -25,13 +26,13 @@ def test_get_password():
 
 @requires_no_keyring
 def test_set_password_no_keyring():
-    with pytest.raises(KeyringUnsupportedError) as exc_info:
+    with pytest.raises(NoKeyringError) as exc_info:
         set_password("harbor_cli_test_user", "harbor_cli_test_password")
     assert "not supported" in str(exc_info.value)
 
 
 @requires_no_keyring
 def test_get_password_no_keyring():
-    with pytest.raises(KeyringUnsupportedError) as exc_info:
+    with pytest.raises(NoKeyringError) as exc_info:
         get_password("harbor_cli_test_user")
     assert "not supported" in str(exc_info.value)

--- a/tests/test_keyring.py
+++ b/tests/test_keyring.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import keyring
 import pytest
-from keyring.errors import NoKeyringError
 
 from .conftest import requires_keyring
 from .conftest import requires_no_keyring
@@ -26,13 +24,13 @@ def test_get_password():
 
 @requires_no_keyring
 def test_set_password_no_keyring():
-    with pytest.raises(NoKeyringError) as exc_info:
+    with pytest.raises(KeyringUnsupportedError) as exc_info:
         set_password("harbor_cli_test_user", "harbor_cli_test_password")
     assert "not supported" in str(exc_info.value)
 
 
 @requires_no_keyring
 def test_get_password_no_keyring():
-    with pytest.raises(NoKeyringError) as exc_info:
+    with pytest.raises(KeyringUnsupportedError) as exc_info:
         get_password("harbor_cli_test_user")
     assert "not supported" in str(exc_info.value)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -106,7 +106,9 @@ def test_state_console() -> None:
 def test_state_client() -> None:
     """Ensure that the client property re-uses the same client object"""
     # de-init singleton for testing
-    State._instance = None
+    State._instance = None  # type: ignore
+    State._initialized = False  # type: ignore
+
     state = State()
     assert not state.is_client_loaded
     default_client = state.client  # the default client
@@ -130,7 +132,9 @@ def test_state_client() -> None:
 def test_state_config() -> None:
     """Ensure that the client property re-uses the same client object"""
     # de-init singleton for testing
-    State._instance = None
+    State._instance = None  # type: ignore
+    State._initialized = False  # type: ignore
+
     state = State()
     # for testing purposes we
     assert not state.is_config_loaded


### PR DESCRIPTION
A small change turned into a cascade of changes needing to be made. Should be split up into several PRs, but that is too much effort for little to no gain. All changes are documented in the changelog.

In short, improves user experience when facing keyring-related errors. Adds a new command `harbor self keyring status` to check the current keyring backend, and also moves the existing `cli-config` command to `self config`.

```
% harbor self --help
                                                                                                                                                    
 Usage: harbor self [OPTIONS] COMMAND [ARGS]...                                                     
                                                                                                    
 Manage the CLI itself.                                                                             
                                                                                                    
╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
│ --help          Show this message and exit.                                                      │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────╮
│ config                 CLI configuration.                                                        │
│ keyring                Manage keyring credentials.                                               │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
```

```
% harbor self keyring --help
                                                                                                    
 Usage: harbor self keyring [OPTIONS] COMMAND [ARGS]...                                             
                                                                                                    
 Manage keyring credentials.                                                                        
                                                                                                    
╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
│ --help          Show this message and exit.                                                      │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────╮
│ status       Show the current keyring backend and its status.                                    │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
```

```
% harbor self config --help 
                                                                                                    
 Usage: harbor self config [OPTIONS] COMMAND [ARGS]...                                              
                                                                                                    
 CLI configuration.                                                                                 
                                                                                                    
╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
│ --help          Show this message and exit.                                                      │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────╮
│ env     Show active Harbor CLI environment variables.                                            │
│ get     Show the current CLI configuration.                                                      │
│ keys    Show all config keys that can be modified with set.                                      │
│ path    Show the path to the current configuration file, or default path if no config is loaded. │
│ set     Modify a CLI configuration value. Use keys to see all available keys.                    │
│ write   Write the current session configuration to disk.                                         │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
```