### PR TITLE
Replace Black with Ruff formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: reorder-python-imports
         args: [--py38-plus, --add-import, "from __future__ import annotations"]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.1.6"
+    rev: "v0.2.0"
     hooks:
       # Run the linter.
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,20 +14,19 @@ repos:
   #   hooks:
   #     - id: pyupgrade
   #       args: [--py38-plus]
-  - repo: https://github.com/psf/black
-    rev: 23.7.0
-    hooks:
-      - id: black
-        language_version: python3.8
   - repo: https://github.com/asottile/reorder_python_imports
     rev: v3.10.0
     hooks:
       - id: reorder-python-imports
         args: [--py38-plus, --add-import, "from __future__ import annotations"]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.286"
+    rev: "v0.1.6"
     hooks:
+      # Run the linter.
       - id: ruff
+        args: [--fix]
+      # Run the formatter.
+      - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.5.1"
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ The **first number** is the major version (API changes, breaking changes)
 The **second number** is the minor version (new features)
 The **third number** is the patch version (bug fixes)
 
+<!-- ## [Unreleased]() - 2024-mm-dd -->
+
 <!-- changelog follows -->
 
-## [Unreleased]() - 2024-mm-dd
+## [0.2.1](https://github.com/unioslo/harbor-cli/tree/harbor-cli-v0.2.1) - 2024-02-02
 
 ### Added
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -26,7 +26,7 @@ See the [Hatch docs](https://hatch.pypa.io/latest/environment/) for more informa
 
 ## Pre-commit hooks
 
-The code is linted and formatted using a pre-commmit configuration consisting of tools such as [Black](https://github.com/psf/black), [Ruff](https://github.com/charliermarsh/ruff), [reorder_python_imports](https://github.com/asottile/reorder_python_imports) and [mypy](https://github.com/python/mypy/).
+The code is linted and formatted using a pre-commmit configuration consisting of tools such as [Ruff](https://github.com/charliermarsh/ruff), [reorder_python_imports](https://github.com/asottile/reorder_python_imports) and [mypy](https://github.com/python/mypy/).
 
 Install pre-commit:
 

--- a/harbor_cli/__about__.py
+++ b/harbor_cli/__about__.py
@@ -3,6 +3,6 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 APP_NAME = "harbor-cli"
 AUTHOR = "unioslo"

--- a/harbor_cli/models.py
+++ b/harbor_cli/models.py
@@ -268,9 +268,7 @@ _USERGROUPTYPE_MAPPING = {
     3: UserGroupType.OIDC,
 }  # type: dict[int, str]
 
-_USERGROUPTYPE_MAPPING_REVERSE = {
-    v: k for k, v in _USERGROUPTYPE_MAPPING.items()
-}  # type: dict[str, int]
+_USERGROUPTYPE_MAPPING_REVERSE = {v: k for k, v in _USERGROUPTYPE_MAPPING.items()}  # type: dict[str, int]
 
 
 # We use this enum to provide choices in the CLI, but we also use it to determine
@@ -308,9 +306,7 @@ _MEMBERROLETYPE_MAPPING = {
     5: MemberRoleType.LIMITED_GUEST,
 }  # type: dict[int, MemberRoleType]
 
-_MEMBERROLETYPE_MAPPING_REVERSE = {
-    v: k for k, v in _MEMBERROLETYPE_MAPPING.items()
-}  # type: dict[MemberRoleType, int]
+_MEMBERROLETYPE_MAPPING_REVERSE = {v: k for k, v in _MEMBERROLETYPE_MAPPING.items()}  # type: dict[MemberRoleType, int]
 
 
 class ArtifactVulnerabilitySummary(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,9 +78,8 @@ dependencies = [
   "pytest-mock>=3.10.0",
   "pytest-timeout>=2.1.0",
   "mypy>=0.991",
-  "black>=22.10.0",
   "hypothesis>=6.62.1",
-  "ruff>=0.0.275",
+  "ruff>=0.2.0",
   "freezegun>=1.2.2",
 ]
 [tool.hatch.envs.default.scripts]
@@ -129,7 +128,7 @@ select = [
   "F", # pyflakes
 ]
 ignore = [
-  "E501", # line too long (we let black handle this)
+  "E501", # line too long (we let ruff formatter handle this)
   "F541", # f-string is missing placeholders
 ]
 src = ["harbor_cli"]


### PR DESCRIPTION
Ruff formatter is largely 1:1 with Black but is [much faster](https://docs.astral.sh/ruff/). This PR also enables `--fix` when running the Ruff linter.